### PR TITLE
refactor instance to allow uid() instead of uid.randomUUID()

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -2,14 +2,14 @@
 // @deno-types="./mod.d.ts"
 import { version } from './version.json';
 
-const DEFAULT_RANDOM_ID_LEN = 6;
+const DEFAULT_RANDOM_ID_LEN: number = 6;
 
-const DIGIT_FIRST_ASCII = 48;
-const DIGIT_LAST_ASCII = 58;
-const ALPHA_LOWER_FIRST_ASCII = 97;
-const ALPHA_LOWER_LAST_ASCII = 123;
-const ALPHA_UPPER_FIRST_ASCII = 65;
-const ALPHA_UPPER_LAST_ASCII = 91;
+const DIGIT_FIRST_ASCII: number = 48;
+const DIGIT_LAST_ASCII: number = 58;
+const ALPHA_LOWER_FIRST_ASCII: number = 97;
+const ALPHA_LOWER_LAST_ASCII: number = 123;
+const ALPHA_UPPER_FIRST_ASCII: number = 65;
+const ALPHA_UPPER_LAST_ASCII: number = 91;
 
 const DICT_RANGES: Ranges = {
   digits: [DIGIT_FIRST_ASCII, DIGIT_LAST_ASCII],
@@ -17,7 +17,13 @@ const DICT_RANGES: Ranges = {
   upperCase: [ALPHA_UPPER_FIRST_ASCII, ALPHA_UPPER_LAST_ASCII],
 };
 
-class ShortUniqueId {
+const DEFAULT_OPTIONS: Options = {
+  dictionary: [],
+  skipShuffle: false,
+  debug: false,
+};
+
+class ShortUniqueId extends Function {
   counter: number;
 
   debug: boolean;
@@ -34,7 +40,7 @@ class ShortUniqueId {
 
   upperBound: number = 0;
 
-  dictLength: number;
+  dictLength: number = 0;
 
   /* tslint:disable consistent-return */
   log(...args: any[]) {
@@ -50,7 +56,14 @@ class ShortUniqueId {
   }
   /* tslint:enable consistent-return */
 
-  constructor(options: Partial<Options> = {}) {
+  constructor(argOptions: Partial<Options> = {}) {
+    super('...args', 'return this.randomUUID(...args)');
+
+    const options: Options = {
+      ...DEFAULT_OPTIONS,
+      ...argOptions as Partial<Options>,
+    };
+
     this.counter = 0;
     this.debug = false;
     this.dict = [];
@@ -61,21 +74,21 @@ class ShortUniqueId {
       skipShuffle,
     } = options;
 
-    if (userDict) {
-      this.dict = userDict;
+    if (userDict && userDict.length > 1) {
+      this.setDictionary(userDict);
     } else {
       let i;
-      /* tslint:disable no-multi-assign */
+
       this.dictIndex = i = 0;
+
       Object.keys(DICT_RANGES).forEach((rangeType: any) => {
-        /* tslint:disable no-undef */
         const rangeTypeKey : keyof Ranges = rangeType as keyof Ranges;
-        /* tslint:enable no-undef */
+
         this.dictRange = DICT_RANGES[rangeTypeKey];
-        /* tslint:disable prefer-destructuring */
+
         this.lowerBound = this.dictRange[0];
         this.upperBound = this.dictRange[1];
-        /* tslint:enable prefer-destructuring */
+
         for (
           this.dictIndex = i = this.lowerBound;
           this.lowerBound <= this.upperBound ? i < this.upperBound : i > this.upperBound;
@@ -84,34 +97,51 @@ class ShortUniqueId {
           this.dict.push(String.fromCharCode(this.dictIndex));
         }
       });
-      /* tslint:enable no-multi-assign */
     }
 
     if (!skipShuffle) {
       // Shuffle Dictionary for removing selection bias.
       const PROBABILITY = 0.5;
-      this.dict = this.dict.sort(() => Math.random() - PROBABILITY);
+      this.setDictionary(this.dict.sort(() => Math.random() - PROBABILITY));
+    } else {
+      this.setDictionary(this.dict);
     }
+
+    this.debug = options.debug;
+    this.log(this.dict);
+    this.log((`Generator instantiated with Dictionary Size ${this.dictLength}`));
+
+    const instance = this.bind(this);
+    Object.getOwnPropertyNames(this).forEach((prop: string) => {
+      if (
+        !(
+          /arguments|caller|callee|length|name|prototype/
+        ).test(prop)
+      ) {
+        const propKey = prop as keyof ShortUniqueId;
+        instance[prop] = this[propKey];
+      }
+    });
+
+    return instance;
+  }
+
+  setDictionary(dictionary: string[]) {
+    this.dict = dictionary;
 
     // Cache Dictionary Length for future usage.
     this.dictLength = this.dict.length;// Resets internal counter.
     this.counter = 0;
-    this.debug = options.debug || this.debug;
-    this.log(this.dict);
-    this.log((`Generator instantiated with Dictionary Size ${this.dictLength}`));
-  }
-
-  getDict() {
-    return this.dict;
   }
 
   /* Generates UUID based on internal counter that's incremented after each ID generation. */
   sequentialUUID() {
     let counterDiv: number;
-    let counterRem;
-    let id;
-    id = '';
+    let counterRem: number;
+    let id: string = '';
+
     counterDiv = this.counter;
+
     /* tslint:disable no-constant-condition */
     while (true) {
       counterRem = counterDiv % this.dictLength;
@@ -123,6 +153,7 @@ class ShortUniqueId {
     }
     /* tslint:enable no-constant-condition */
     this.counter += 1;
+
     return id;
   }
 
@@ -131,10 +162,7 @@ class ShortUniqueId {
     let id;
     let randomPartIdx;
     let j;
-
-    /* tslint:disable no-unused-vars */
     let idIndex;
-    /* tslint:enable no-unused-vars */
 
     if ((uuidLength === null || typeof uuidLength === 'undefined') || uuidLength < 1) {
       throw new Error('Invalid UUID Length Provided');
@@ -142,7 +170,6 @@ class ShortUniqueId {
 
     // Generate random ID parts from Dictionary.
     id = '';
-    /* tslint:disable */
     for (
       idIndex = j = 0;
       0 <= uuidLength ? j < uuidLength : j > uuidLength;
@@ -151,7 +178,6 @@ class ShortUniqueId {
       randomPartIdx = Math.trunc(Math.random() * this.dictLength) % this.dictLength;
       id += this.dict[randomPartIdx];
     }
-    /* tslint:enable */
 
     // Return random generated ID.
     return id;

--- a/test.ts
+++ b/test.ts
@@ -15,9 +15,9 @@ test({
     const uidCollection: string[] = [];
 
     /* tslint:disable no-magic-numbers */
-    uidCollection.push(uid.randomUUID(6));
-    uidCollection.push(uid.randomUUID(7));
-    uidCollection.push(uid.randomUUID(10));
+    uidCollection.push(uid(6));
+    uidCollection.push(uid(7));
+    uidCollection.push(uid(10));
     assertEquals(uidCollection[0].length, 6);
     assertEquals(uidCollection[1].length, 7);
     assertEquals(uidCollection[2].length, 10);
@@ -36,7 +36,7 @@ test({
   name: 'Short Unique ID is able to generate consecutive id\'s based on internal counter',
   fn(): void {
     const uid: ShortUniqueId = new ShortUniqueId();
-    uid.dict = ['v', '0', 'Y'];
+    uid.setDictionary(['v', '0', 'Y']);
     assertEquals(uid.sequentialUUID(), 'v');
     assertEquals(uid.sequentialUUID(), '0');
     assertEquals(uid.sequentialUUID(), 'Y');
@@ -46,8 +46,17 @@ test({
 test({
   name: 'Short Unique ID is able to be instantiated with user-defined dictionary',
   fn(): void {
-    const uid: ShortUniqueId = new ShortUniqueId({ dictionary: ['a', '1'] });
-    assert((/^[a1][a1]$/).test(uid.dict.join('')));
+    const uid: ShortUniqueId = new ShortUniqueId({
+      dictionary: ['a', '1'],
+      skipShuffle: true,
+    });
+    /* tslint:disable no-magic-numbers */
+    assert((/^[a1][a1]$/).test(uid(2)));
+    /* tslint:enable no-magic-numbers */
+    assertEquals(
+      [uid.sequentialUUID(), uid.sequentialUUID()].join(''),
+      'a1',
+    );
   },
 });
 


### PR DESCRIPTION
Decided to keep `uid.randomUUID()` as "verbose mode" so that `uid()` becomes its short form.

For some reason, even though [this stackoverflow answer](https://stackoverflow.com/a/49280381/2731075) works just fine, for my use case I had to re-add all properties to the instance like this:

```
    const instance = this.bind(this);
    Object.getOwnPropertyNames(this).forEach((prop: string) => {
      if (
        !(
          /arguments|caller|callee|length|name|prototype/
        ).test(prop)
      ) {
        const propKey = prop as keyof ShortUniqueId;
        instance[prop] = this[propKey];
      }
    });

```

Otherwise instance functions (specifically sequentialUUID) would fail due to being unable to access dict and counter as they appeared as undefined.

It is a bit of a code smell that sequentialUUID would fail but not randomUUID, so we might need to add a more thorough check of the given dictionary, bot upon initialization and usage. Tests are passing, so for now the cases handled these proposed checks might be more useful in edge cases where dictionaries are set in a more complex fashion.